### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,7 @@ octo-analyser/
 ├── docker-compose.yml            # Service orchestration driven by TARGET_HOST variable
 ├── .dockerignore
 ├── .editorconfig
+├── CHANGELOG.md
 ├── CONTRIBUTING.md
 ├── LICENSE
 └── README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- created `CLAUDE.md` with build commands, architecture overview, and Dockerfile conventions
+
 ### Changed
+
+- refreshed `.github/copilot-instructions.md` repository structure to include `CHANGELOG.md`
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Docker Compose-based security scanning toolkit. Each tool lives in its own directory with a single Dockerfile. Orchestrated via `docker-compose.yml` using the `TARGET_HOST` environment variable.
+
+## Build & Run
+
+```bash
+docker-compose build              # all images (Nmap compiles from source — slow)
+docker-compose build <service>    # single service: nmap, nikto, wfuzz
+
+TARGET_HOST=192.168.1.100 docker-compose up nmap
+TARGET_HOST=192.168.1.100 docker-compose up nikto
+TARGET_HOST=http://192.168.1.100 docker-compose up wfuzz
+TARGET_HOST=192.168.1.100 docker-compose up           # all services
+```
+
+Override default scan arguments with `docker-compose run`:
+
+```bash
+TARGET_HOST=10.0.0.1 docker-compose run nmap -sU -sV -p 53,161,500 10.0.0.1
+```
+
+## Architecture
+
+- **One tool per directory.** `nmap/`, `nikto/`, `wfuzz/` each contain one `Dockerfile`. Placeholder directories (`arachni/`, `dirsearch/`, `reconnoitre/`) have empty Dockerfiles reserving the structure.
+- **Source compilation.** Nmap is compiled from the official tarball on Alpine for exact version pinning. Build deps are removed in the same `RUN` layer.
+- **Environment-driven targets.** All services read `TARGET_HOST` from the calling shell. No secrets or targets are hardcoded.
+- **Compose version 3.3.** Services define `ENTRYPOINT` in their Dockerfile; the `command` key in `docker-compose.yml` passes scan arguments.
+
+## Dockerfile Conventions
+
+- Chain commands with `&&` and `\` continuations. Clean caches (`rm -rf /var/cache/apk/*`) in the same layer.
+- Run tools as a dedicated non-root user where practical (see `nikto/Dockerfile` as reference).
+- Pin exact versions for base images and tool releases.
+- `ENTRYPOINT` must invoke the tool binary directly so `docker-compose run` can pass arguments verbatim.
+
+## Dependencies
+
+No `package.json`, `requirements.txt`, or `go.mod` at repo root. All dependencies are managed inside individual Dockerfiles.
+
+Runtime: Docker 20+, Docker Compose v2+.
+
+## Conventions
+
+Follow [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow) and the [Development Guide](https://github.com/rios0rios0/guide/wiki). See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.